### PR TITLE
Merge new API spec

### DIFF
--- a/doc/api/spec/0.0.1-preview.yaml
+++ b/doc/api/spec/0.0.1-preview.yaml
@@ -234,7 +234,8 @@ paths:
           description: The ISBN of the book to checkout.
           in: body
           required: true
-          type: string
+          schema:
+            type: string
       responses:
         200:
           description: Book checked out (loan returned)

--- a/doc/api/spec/0.0.1-preview.yaml
+++ b/doc/api/spec/0.0.1-preview.yaml
@@ -216,7 +216,8 @@ paths:
         200:
           description: Books returned
           schema:
-            title: Book
+            title: Books
+            type: array
             items:
               $ref: '#/definitions/Book'
         401:


### PR DESCRIPTION
 + First pass on responses for loans API
 + Fixed broken swagger for `POST /loan/`
 + Changed `GET /loan/` to return an array of  `Book`s

