### PR TITLE
Add sorting parameters to API

### DIFF
--- a/doc/api/spec/0.0.1-preview.yaml
+++ b/doc/api/spec/0.0.1-preview.yaml
@@ -139,6 +139,11 @@ paths:
           type: integer
           format: int32
           default: 10
+        - name: sort-by
+          description: How to sort the returned list. Options are "first" for first name and "last" for last name.
+          in: query
+          required: false
+          type: string
       responses:
         200:
           description: List all authors
@@ -308,3 +313,4 @@ definitions:
         format: int32
       message:
         type: string
+        

--- a/doc/api/spec/0.0.1-preview.yaml
+++ b/doc/api/spec/0.0.1-preview.yaml
@@ -33,6 +33,11 @@ paths:
           type: integer
           format: int32
           default: 10
+        - name: sort-by
+          description: How to sort the returned list. Options are "title" for alphabetical order by title and "date" for publication date.
+          in: query
+          required: false
+          type: string
       responses:
         200:
           description: List all books


### PR DESCRIPTION
Adds parameters for sorting the `GET /authors` and `GET /books` routes.

Closes #44 and #57 